### PR TITLE
Build DPI from source when running GitHub actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [ main ]
 
+  workflow_dispatch:
+
 jobs:
   build:
 

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -28,13 +28,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: build DPI from source
       run: |
-         sudo apt-get update-y && install -y libxml2-dev libpcap-dev
+         sudo apt update -y && sudo apt install -y libxml2-dev libpcap-dev
          git clone https://github.com/Montimage/mmt-dpi.git mmt-dpi
          cd mmt-dpi/sdk/ && make -j2 && sudo make install
          
     - name: build-from-source
       run: |
-         sudo apt-get update -y && sudo apt-get install -y libxml2-dev libpcap-dev libconfuse-dev libpcap-dev
+         sudo apt update -y && sudo apt install -y libxml2-dev libpcap-dev libconfuse-dev libpcap-dev
          make clean-all && make DEBUG=1 && make deb && make check VERBOSE=1  && sudo make install
 
     #The following steps are executed only on new tag

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,7 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ main, "*" ]
+    branches: [ main ]
     tags: ["v*"] # Push events to matching v*, i.e. v1.0, v20.15.10
   pull_request:
     branches: [ main ]
@@ -24,10 +24,14 @@ jobs:
         EOF
 
     - uses: actions/checkout@v2
+    - name: build DPI from source
+      run: |
+         sudo apt-get update-y && install -y libxml2-dev libpcap-dev
+         git clone https://github.com/Montimage/mmt-dpi.git mmt-dpi
+         cd mmt-dpi/sdk/ && make -j2 && sudo make install
+         
     - name: build-from-source
       run: |
-         wget --no-verbose -O mmt-dpi.deb https://github.com/Montimage/mmt-dpi/releases/download/v1.7.7/mmt-dpi_1.7.7_bb5a717_Linux_x86_64.deb
-         sudo dpkg -i mmt-dpi.deb
          sudo apt-get update -y && sudo apt-get install -y libxml2-dev libpcap-dev libconfuse-dev libpcap-dev
          make clean-all && make DEBUG=1 && make deb && make check VERBOSE=1  && sudo make install
 

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ gen_dpi_header
 .project
 .cproject
 rsync.sh
+.swp
+.project


### PR DESCRIPTION
The GitHub actions was fixed on a version 1.7.7 of MMT-DPI. This prevents using new features from new DPI version in MMT-Security. This pr allows building DPI from its latest source code. Even compiling DPI from its source might require more time, thus GitHub actions will run longer.
