### PR TITLE
fix buffer overflow errors

### DIFF
--- a/src/lib/mmt_security.c
+++ b/src/lib/mmt_security.c
@@ -428,6 +428,7 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 	static __thread_scope char buffer[ MAX_STR_SIZE + 1 ];
 	char *str_ptr, *c_ptr;
 	size_t size, i, j, index, n, e_len;
+	size_t remaining_len;
 	int total_len;
 	const message_t *msg;
 	const message_element_t *me;
@@ -463,7 +464,8 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 			*(str_ptr ++) = ',';
 
 		//event 's detail
-		size = snprintf( str_ptr, total_len, "\"event_%zu\":{\"timestamp\":%ld.%06ld,\"counter\":%"PRIu64",\"attributes\":[",
+		remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+		size = snprintf( str_ptr, remaining_len, "\"event_%zu\":{\"timestamp\":%ld.%06ld,\"counter\":%"PRIu64",\"attributes\":[",
 						index,
 						time.tv_sec, //timestamp: second
 						time.tv_usec, //timestamp: microsecond
@@ -499,7 +501,8 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 			str_ptr += size;
 
 			//do not forget ]
-			size = snprintf( str_ptr, total_len, "%s[\"%s.%s\",", //[key, value]
+			remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+			size = snprintf( str_ptr, remaining_len, "%s[\"%s.%s\",", //[key, value]
 					(is_first? "":","),
 					pro_ptr->proto,
 					pro_ptr->att);
@@ -513,7 +516,8 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 				double_val = *(double *)me->data;
 
 				//do not forget }
-				size = snprintf( str_ptr, total_len, "%.2f", double_val );
+				remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+				size = snprintf( str_ptr, remaining_len, "%.2f", double_val );
 
 				c_ptr = str_ptr + size;
 				//remove zero at the end, e.g., 10.00 ==> 10
@@ -533,18 +537,18 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 
 
 				u8_ptr = NULL;
-
+				remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
 				switch( pro_ptr->dpi_type ){
 				case MMT_DATA_TIMEVAL:
 					u8_ptr = (uint8_t *) me->data;
 					ptime  = (struct timeval *) me->data;
-					size   = snprintf(str_ptr, total_len, "%ld.%06ld",
-							ptime->tv_sec, ptime->tv_usec );
+					size   = snprintf(str_ptr, remaining_len, "%ld.%06ld",
+						ptime->tv_sec, ptime->tv_usec );
 					break;
 				case MMT_DATA_IP_NET: /**< ip network address constant value */
 				case MMT_DATA_IP_ADDR: /**< ip address constant value */
 						u8_ptr = (uint8_t *) me->data;
-						size   = snprintf(str_ptr, total_len, "\"%d.%d.%d.%d\"",
+						size   = snprintf(str_ptr, remaining_len, "\"%d.%d.%d.%d\"",
 											u8_ptr[0], u8_ptr[1], u8_ptr[2], u8_ptr[3] );
 					break;
 
@@ -559,8 +563,8 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					//MAC address
 				case MMT_DATA_MAC_ADDR:
 						u8_ptr = (uint8_t *) me->data;
-						size   = snprintf(str_ptr, total_len, "\"%02x:%02x:%02x:%02x:%02x:%02x\"",
-								u8_ptr[0], u8_ptr[1], u8_ptr[2], u8_ptr[3], u8_ptr[4], u8_ptr[5] );
+						size   = snprintf(str_ptr, remaining_len, "\"%02x:%02x:%02x:%02x:%02x:%02x\"",
+							u8_ptr[0], u8_ptr[1], u8_ptr[2], u8_ptr[3], u8_ptr[4], u8_ptr[5] );
 					break;
 				case MMT_U16_ARRAY:
 				case MMT_U32_ARRAY:

--- a/src/lib/mmt_security.c
+++ b/src/lib/mmt_security.c
@@ -506,7 +506,7 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					(is_first? "":","),
 					pro_ptr->proto,
 					pro_ptr->att);
-
+			if (size >= remaining_len) size = remaining_len > 0 ? remaining_len - 1 : 0;
 			str_ptr   += size;
 			total_len -= size;
 
@@ -557,7 +557,7 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					u8_ptr = (uint8_t *) me->data;
 					char ip_string[ INET6_ADDRSTRLEN ];
 					if( inet_ntop(AF_INET6, (void*) u8_ptr, ip_string, INET6_ADDRSTRLEN )){
-						size =  sprintf( str_ptr, "\"%s\"", ip_string );
+						size =  snprintf( str_ptr, remaining_len, "\"%s\"", ip_string );
 					}
 					break;
 					//MAC address
@@ -575,14 +575,14 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					str_ptr  ++;
 					n     = _get_u( u8_ptr, 4 ); //first 4 bytes is length of the array
 					e_len = _get_len( pro_ptr->dpi_type ); //data length of each element in the array
-					total_len --;
-
 					for( j=0; j<n; j++ ){
-						if( total_len < 3 )
+						remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+						if( remaining_len < 3 )
 							break;
-						size = snprintf( str_ptr, total_len, (j == 0 ? "%zu": ",%zu"),
+						size = snprintf( str_ptr, remaining_len, (j == 0 ? "%zu": ",%zu"),
 								//+4 bytes for the array length
 								_get_u( &u8_ptr[j * e_len + 4], e_len) );
+						if (size >= remaining_len) size = remaining_len - 1;
 						//exclude the last '\0' character
 						total_len -= size;
 						str_ptr   += size;
@@ -600,7 +600,8 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					//TODO: limit output length of one proto.att to 255 bytes
 					*str_ptr = '"';
 					str_ptr ++;
-					size = _copy_plein_text(  str_ptr, total_len - 20, (char *) me->data );
+					remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+					size = _copy_plein_text(  str_ptr, remaining_len > 20 ? remaining_len - 20 : 0, (char *) me->data );
 					str_ptr[ size ] = '"';
 					size ++;
 				}
@@ -622,7 +623,8 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 		if( unlikely( total_len <= 0 )){
 			mmt_warn("Buffer size is not enough to contain all attributes");
 			//close
-			str_ptr += snprintf( str_ptr, total_len, "]}") ;
+			remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+			str_ptr += snprintf( str_ptr, remaining_len, "]}") ;
 			break;
 		}
 

--- a/src/lib/mmt_security.c
+++ b/src/lib/mmt_security.c
@@ -426,12 +426,12 @@ static uint16_t _get_len( int dpi_type ){
 
 static const char* _convert_execution_trace_to_json_string( const mmt_array_t *trace, const rule_info_t *rule ){
 	static __thread_scope char buffer[ MAX_STR_SIZE + 1 ];
-	char *str_ptr, *c_ptr;
+	char *str_ptr, *c_ptr, *event_start;
 	size_t size, i, j, index, n, e_len;
 	size_t remaining_len;
 	const message_t *msg;
 	const message_element_t *me;
-	bool is_first;
+	bool is_first, truncated;
 	struct timeval time, *ptime;
 	const mmt_array_t *proto_atts_event; //proto_att of an event
 	const proto_attribute_t *pro_ptr;
@@ -456,8 +456,15 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 		if( msg == NULL ) continue;
 
 		mmt_sec_decode_timeval( msg->timestamp, &time );
+		event_start = str_ptr;
+		truncated   = NO;
 
-		//seperator of each event
+		//separator of each event
+		remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+		if( unlikely( remaining_len == 0 ) ){
+			mmt_warn("Buffer size is not enough to contain all attributes");
+			break;
+		}
 		if( str_ptr > buffer + 1 )
 			*(str_ptr ++) = ',';
 
@@ -468,6 +475,11 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 						time.tv_sec, //timestamp: second
 						time.tv_usec, //timestamp: microsecond
 						msg->counter );
+		if( unlikely( size >= remaining_len ) ){
+			mmt_warn("Buffer size is not enough to contain all attributes");
+			str_ptr = event_start;
+			break;
+		}
 
 		is_first = YES;
 
@@ -491,10 +503,6 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 			if( j>= proto_atts_event->elements_count )
 				continue;
 
-			if( size >= remaining_len ){
-				break;
-			}
-
 			str_ptr += size;
 
 			//do not forget ]
@@ -503,8 +511,11 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					(is_first? "":","),
 					pro_ptr->proto,
 					pro_ptr->att);
-			if (size >= remaining_len) size = remaining_len > 0 ? remaining_len - 1 : 0;
-			str_ptr   += size;
+			if( unlikely( size >= remaining_len ) ){
+				truncated = YES;
+				break;
+			}
+			str_ptr += size;
 
 			//pro_ptr->data_type;
 			switch( me->data_type ){
@@ -514,7 +525,10 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 				//do not forget }
 				remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
 				size = snprintf( str_ptr, remaining_len, "%.2f", double_val );
-				if (size >= remaining_len) size = remaining_len > 0 ? remaining_len - 1 : 0;
+				if( unlikely( size >= remaining_len ) ){
+					truncated = YES;
+					break;
+				}
 
 				if (size > 0) {
 					c_ptr = str_ptr + size;
@@ -532,8 +546,6 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 				break;
 
 			default:
-
-
 				u8_ptr = NULL;
 				remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
 				switch( pro_ptr->dpi_type ){
@@ -545,80 +557,129 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					break;
 				case MMT_DATA_IP_NET: /**< ip network address constant value */
 				case MMT_DATA_IP_ADDR: /**< ip address constant value */
-						u8_ptr = (uint8_t *) me->data;
-						size   = snprintf(str_ptr, remaining_len, "\"%d.%d.%d.%d\"",
-											u8_ptr[0], u8_ptr[1], u8_ptr[2], u8_ptr[3] );
+					u8_ptr = (uint8_t *) me->data;
+					size   = snprintf(str_ptr, remaining_len, "\"%d.%d.%d.%d\"",
+								u8_ptr[0], u8_ptr[1], u8_ptr[2], u8_ptr[3] );
 					break;
 
 					//IPV6 address
 				case MMT_DATA_IP6_ADDR: {
 					char ip_string[ INET6_ADDRSTRLEN ];
 					u8_ptr = (uint8_t *) me->data;
-					if( inet_ntop(AF_INET6, (void*) u8_ptr, ip_string, INET6_ADDRSTRLEN )){
-						size =  snprintf( str_ptr, remaining_len, "\"%s\"", ip_string );
-					}
+					if( inet_ntop(AF_INET6, (void*) u8_ptr, ip_string, INET6_ADDRSTRLEN ) )
+						size = snprintf( str_ptr, remaining_len, "\"%s\"", ip_string );
+					else
+						size = 0;
 					break;
 				}
 					//MAC address
 				case MMT_DATA_MAC_ADDR:
-						u8_ptr = (uint8_t *) me->data;
-						size   = snprintf(str_ptr, remaining_len, "\"%02x:%02x:%02x:%02x:%02x:%02x\"",
+					u8_ptr = (uint8_t *) me->data;
+					size   = snprintf(str_ptr, remaining_len, "\"%02x:%02x:%02x:%02x:%02x:%02x\"",
 							u8_ptr[0], u8_ptr[1], u8_ptr[2], u8_ptr[3], u8_ptr[4], u8_ptr[5] );
 					break;
 				case MMT_U16_ARRAY:
 				case MMT_U32_ARRAY:
 				case MMT_U64_ARRAY:
 					u8_ptr = (uint8_t *) me->data;
-					//group the  numbers in [ and ]
+					remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+					if( unlikely( remaining_len < 2 ) ){
+						truncated = YES;
+						break;
+					}
+					//group the numbers in [ and ]
 					*str_ptr = '[';
-					str_ptr  ++;
+					str_ptr ++;
 					n     = _get_u( u8_ptr, 4 ); //first 4 bytes is length of the array
 					e_len = _get_len( pro_ptr->dpi_type ); //data length of each element in the array
 					for( j=0; j<n; j++ ){
 						remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
-						if( remaining_len < 3 )
+						if( unlikely( remaining_len < 3 ) ){
+							truncated = YES;
 							break;
+						}
 						size = snprintf( str_ptr, remaining_len, (j == 0 ? "%zu": ",%zu"),
 								//+4 bytes for the array length
 								_get_u( &u8_ptr[j * e_len + 4], e_len) );
-						if (size >= remaining_len) size = remaining_len - 1;
-						str_ptr   += size;
+						if( unlikely( size >= remaining_len ) ){
+							truncated = YES;
+							break;
+						}
+						str_ptr += size;
+					}
+					if( truncated )
+						break;
+					remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+					if( unlikely( remaining_len == 0 ) ){
+						truncated = YES;
+						break;
 					}
 					*str_ptr = ']';
 					str_ptr ++;
 
-					//whe reset size to zero so that str_ptr will not increase in line 603
+					//we reset size to zero so that str_ptr will not increase again below
 					size = 0;
 					break;
 				}// end of switch( pro_ptr->proto_id ){
 
+				if( truncated )
+					break;
+				if( unlikely( size >= remaining_len ) ){
+					truncated = YES;
+					break;
+				}
+
 				//if the attribute is not neither IP nor MAC
 				if( u8_ptr == NULL ){
+					remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+					if( unlikely( remaining_len < 1 ) ){
+						truncated = YES;
+						break;
+					}
 					//TODO: limit output length of one proto.att to 255 bytes
 					*str_ptr = '"';
 					str_ptr ++;
 					remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+					if( unlikely( remaining_len == 0 ) ){
+						truncated = YES;
+						break;
+					}
 					size = _copy_plein_text(  str_ptr, remaining_len > 20 ? remaining_len - 20 : 0, (char *) me->data );
+					if( unlikely( size >= remaining_len ) ){
+						truncated = YES;
+						break;
+					}
 					str_ptr[ size ] = '"';
 					size ++;
 				}
-				//
-
 			}//end of switch( me->data_type )
+			if( truncated )
+				break;
 
 			//close ] here
+			remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+			if( unlikely( remaining_len <= size ) ){
+				truncated = YES;
+				break;
+			}
 			str_ptr += size;
 			*str_ptr = ']';
 			*(str_ptr + 1 ) = '\0';
 
 			size = 1;
-
 			is_first = NO;
 		}
 
-		remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
-		if( unlikely( remaining_len < 3 )){
+		if( truncated ){
 			mmt_warn("Buffer size is not enough to contain all attributes");
+			str_ptr = event_start;
+			break;
+		}
+
+		remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+		if( unlikely( remaining_len < 4 ) ){
+			mmt_warn("Buffer size is not enough to contain all attributes");
+			str_ptr = event_start;
 			break;
 		}
 

--- a/src/lib/mmt_security.c
+++ b/src/lib/mmt_security.c
@@ -429,7 +429,6 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 	char *str_ptr, *c_ptr;
 	size_t size, i, j, index, n, e_len;
 	size_t remaining_len;
-	int total_len;
 	const message_t *msg;
 	const message_element_t *me;
 	bool is_first;
@@ -450,8 +449,7 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 			"Impossible: elements_count > events_count (%zu > %d + 1)", trace->elements_count, rule->events_count);
 #endif
 
-	total_len = MAX_STR_SIZE;
-	str_ptr   = buffer+1;
+	str_ptr = buffer + 1;
 
 	for( index=0; index<trace->elements_count; index ++ ){
 		msg = trace->data[ index ];
@@ -460,7 +458,7 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 		mmt_sec_decode_timeval( msg->timestamp, &time );
 
 		//seperator of each event
-		if( total_len != MAX_STR_SIZE )
+		if( str_ptr > buffer + 1 )
 			*(str_ptr ++) = ',';
 
 		//event 's detail
@@ -493,8 +491,7 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 			if( j>= proto_atts_event->elements_count )
 				continue;
 
-			total_len -= size;
-			if( unlikely( total_len <= 0 )){
+			if( size >= remaining_len ){
 				break;
 			}
 
@@ -508,7 +505,6 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					pro_ptr->att);
 			if (size >= remaining_len) size = remaining_len > 0 ? remaining_len - 1 : 0;
 			str_ptr   += size;
-			total_len -= size;
 
 			//pro_ptr->data_type;
 			switch( me->data_type ){
@@ -518,16 +514,18 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 				//do not forget }
 				remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
 				size = snprintf( str_ptr, remaining_len, "%.2f", double_val );
+				if (size >= remaining_len) size = remaining_len > 0 ? remaining_len - 1 : 0;
 
-				c_ptr = str_ptr + size;
-				//remove zero at the end, e.g., 10.00 ==> 10
-				while( *c_ptr == '0' || *c_ptr == '\0' ){
-					c_ptr --;
-					size --;
+				if (size > 0) {
+					c_ptr = str_ptr + size;
+					//remove zero at the end, e.g., 10.00 ==> 10
+					while( *c_ptr == '0' || *c_ptr == '\0' ){
+						c_ptr --;
+						size --;
 
-					if( *c_ptr == '.'){
-						//size --;
-						break;
+						if( *c_ptr == '.'){
+							break;
+						}
 					}
 				}
 
@@ -553,13 +551,14 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					break;
 
 					//IPV6 address
-				case MMT_DATA_IP6_ADDR:
-					u8_ptr = (uint8_t *) me->data;
+				case MMT_DATA_IP6_ADDR: {
 					char ip_string[ INET6_ADDRSTRLEN ];
+					u8_ptr = (uint8_t *) me->data;
 					if( inet_ntop(AF_INET6, (void*) u8_ptr, ip_string, INET6_ADDRSTRLEN )){
 						size =  snprintf( str_ptr, remaining_len, "\"%s\"", ip_string );
 					}
 					break;
+				}
 					//MAC address
 				case MMT_DATA_MAC_ADDR:
 						u8_ptr = (uint8_t *) me->data;
@@ -583,8 +582,6 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 								//+4 bytes for the array length
 								_get_u( &u8_ptr[j * e_len + 4], e_len) );
 						if (size >= remaining_len) size = remaining_len - 1;
-						//exclude the last '\0' character
-						total_len -= size;
 						str_ptr   += size;
 					}
 					*str_ptr = ']';
@@ -619,12 +616,9 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 			is_first = NO;
 		}
 
-		total_len -= size;
-		if( unlikely( total_len <= 0 )){
+		remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
+		if( unlikely( remaining_len < 3 )){
 			mmt_warn("Buffer size is not enough to contain all attributes");
-			//close
-			remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1;
-			str_ptr += snprintf( str_ptr, remaining_len, "]}") ;
 			break;
 		}
 
@@ -634,8 +628,11 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 		*(str_ptr ++) = '}';
 	}
 
-	*(str_ptr++) = '}'; //end of all
-	*(str_ptr++) = '\0';
+	remaining_len = sizeof(buffer) - (str_ptr - buffer);
+	if( likely( remaining_len >= 2 ) ){
+		*(str_ptr++) = '}'; //end of all
+		*str_ptr = '\0';
+	}
 
 	return buffer;
 }

--- a/src/lib/mmt_security.c
+++ b/src/lib/mmt_security.c
@@ -568,8 +568,10 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 					u8_ptr = (uint8_t *) me->data;
 					if( inet_ntop(AF_INET6, (void*) u8_ptr, ip_string, INET6_ADDRSTRLEN ) )
 						size = snprintf( str_ptr, remaining_len, "\"%s\"", ip_string );
-					else
-						size = 0;
+					else {
+						truncated = YES;
+						break;
+					}
 					break;
 				}
 					//MAC address
@@ -664,7 +666,6 @@ static const char* _convert_execution_trace_to_json_string( const mmt_array_t *t
 			}
 			str_ptr += size;
 			*str_ptr = ']';
-			*(str_ptr + 1 ) = '\0';
 
 			size = 1;
 			is_first = NO;


### PR DESCRIPTION
This fixes use the new variable \"remaining_len\" to control the real remaining length of the buffer in the function _convert_execution_trace_to_json_string

Closes #16

## Decision Record

**Root cause:** `_convert_execution_trace_to_json_string` used a single `total_len` counter (decremented as writes happened) rather than computing remaining capacity from the current pointer position. On event boundaries this could advance `str_ptr` one byte past `buffer` and produce a `size_t` underflow in the next `remaining_len` computation, passing a huge length to `snprintf`.

**Options considered:**
1. Keep `total_len` but fix the off-by-one arithmetic at each boundary.
2. Replace `total_len` with a per-write `remaining_len = sizeof(buffer) - (str_ptr - buffer) - 1` computation.
3. Introduce a safe-write helper that encapsulates the bounds check.

**Options rejected:**
- Option 1: the accumulated-decrement approach is fragile; any future write that skips the decrement reintroduces the bug.
- Option 3: adds indirection without simplifying the callers meaningfully at this scale.

**Selected option:** Option 2 — recompute `remaining_len` from pointer arithmetic before every `snprintf` or direct byte write. Track per-event start with `event_start`; on any truncation revert `str_ptr` to `event_start` and stop, guaranteeing the returned JSON is always well-formed.

**Residual risk:** `inet_ntop` failure (unusual in practice) now safely aborts the current event rather than emitting a valueless `["proto.att",]` entry. The `_copy_plein_text` limit is intentionally capped at `remaining_len - 20` to leave headroom for the surrounding JSON delimiters.

## Acceptance Criteria Verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| 1 | `str_ptr` never advances beyond the bounds of `buffer`, including event boundaries | pass | `event_start` captures position before each event; every advance is gated on a `remaining_len` check; truncation reverts to `event_start` (`mmt_security.c:459,675`) |
| 2 | Function exits safely without OOB write or `size_t` underflow when space is insufficient | pass | `remaining_len` recomputed from `sizeof(buffer) - (str_ptr - buffer) - 1` before each write; `remaining_len == 0` and `size >= remaining_len` checks guard all paths (`mmt_security.c:463–482`) |
| 3 | Truncation paths do not produce malformed JSON | pass | Truncated events are dropped entirely (revert to `event_start`); `inet_ntop` failure now sets `truncated=YES` rather than writing an empty value, preventing `["proto.att",]` output (`mmt_security.c:570–574`) |